### PR TITLE
Fix Tentacles failing to upstream Purpur

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 group = org.purpurmc.tentacles
 version = 1.19.3-R0.1-SNAPSHOT
 
-purpurCommit = ecc06717ccf608d8f849c6b34c9f872bd0d45778
+purpurCommit = 295ffae9eb39e98b9f5a9929cd988750d96f8656
 
 org.gradle.caching = true
 org.gradle.parallel = true

--- a/patches/server/0001-Rebrand.patch
+++ b/patches/server/0001-Rebrand.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Rebrand
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 7de4b51cb4afdcbdfb8d1dc32f56252d997e23a8..a0d2d1058446137bebe00290861467b2dc668fbc 100644
+index d5b7458f6b79addf1a12eb82443ba5bdbe2ea5d3..e10e82a4303969dde0c53389749368841932c757 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -7,7 +7,7 @@ plugins {
@@ -14,10 +14,10 @@ index 7de4b51cb4afdcbdfb8d1dc32f56252d997e23a8..a0d2d1058446137bebe00290861467b2
  dependencies {
 -    implementation(project(":purpur-api")) // Purpur
 +    implementation(project(":tentacles-api")) // Purpur // Tentacles
+     // Pufferfish start
      implementation("io.papermc.paper:paper-mojangapi:1.19.3-R0.1-SNAPSHOT") {
          exclude("io.papermc.paper", "paper-api")
-     }
-@@ -66,7 +66,7 @@ tasks.jar {
+@@ -83,7 +83,7 @@ tasks.jar {
          attributes(
              "Main-Class" to "org.bukkit.craftbukkit.Main",
              "Implementation-Title" to "CraftBukkit",
@@ -61,7 +61,7 @@ index fba5dbdb7bcbb55400ef18342c9b54612972a718..d7fddab809b7514d93e7969eb574c5d6
          switch (distance) {
              case -1:
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 80d4167edd7c87240ce02ae122153976015d548a..880de2a7de4263b4bb216aad5ce166e95ffa7946 100644
+index fbfd5ea459ab2751bf100c43c4f0398f579c8fdb..3d134895f326a997fb349b783fc7880cdd424ade 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -262,7 +262,7 @@ import javax.annotation.Nullable; // Paper


### PR DESCRIPTION
This small pull request fixes Tentacles failing to upstream Purpur due to the reintroduction of Pufferfish patches causing merge conflicts