### PR TITLE
Update to 1.21.5

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ group = org.purpurmc.tentacles
 version = 1.21.5-R0.1-SNAPSHOT
 
 mcVersion=1.21.5
-purpurCommit = 8b5044e007de621325169d6ea8e1765fcec0e394
+purpurCommit = 6cc78b6308cabed2ebea27087b821c2421f6e1ff
 
 org.gradle.caching = true
 org.gradle.parallel = true

--- a/scripts/updateUpstream.sh
+++ b/scripts/updateUpstream.sh
@@ -7,7 +7,7 @@ set -e
 PS1="$"
 
 current=$(cat gradle.properties | grep purpurCommit | sed 's/purpurCommit = //')
-upstream=$(git ls-remote https://github.com/PurpurMC/Purpur | grep ver/1.21.4 | cut -f 1)
+upstream=$(git ls-remote https://github.com/PurpurMC/Purpur | grep ver/1.21.5 | cut -f 1)
 
 if [ "$current" != "$upstream" ]; then
     sed -i 's/purpurCommit = .*/purpurCommit = '"$upstream"'/' gradle.properties

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,7 +8,7 @@ pluginManagement {
 }
 
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.5.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.9.0"
 }
 
 if (!file(".git").exists()) {


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly

Purpur Changes:
PurpurMC/Purpur@f2f682f Updated Upstream (Paper)
PurpurMC/Purpur@bdeba76 Updated Upstream (Paper)
PurpurMC/Purpur@96f5b04 drop void damage height/damage migration PurpurMC/Purpur@6cc78b6 Updated Upstream (Paper)